### PR TITLE
App Orientation locked

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:dynamic_theme/dynamic_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:news_retic/Screens/HomePage.dart';
 import 'package:news_retic/Screens/splashScreen.dart';
 
@@ -22,6 +23,11 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
+
     return DynamicTheme(
         defaultBrightness: Brightness.light,
         data: (brightness) => new ThemeData(


### PR DESCRIPTION
Fixes #13  Landscape Screen Orientation

**Changes**
Preferred Orientations are now set to Portrait mode only.

**Screenshot**
![ss](https://user-images.githubusercontent.com/53324291/96060351-e17b0900-0ead-11eb-9c9d-185ce69f22a9.PNG)
